### PR TITLE
Alow higher cache versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "cache/tag-interop": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",


### PR DESCRIPTION
This pull request makes a small update to the `composer.json` file, expanding the supported versions of the `psr/simple-cache` dependency to include versions 2.0 and 3.0 in addition to 1.0. This improves compatibility with newer versions of the `psr/simple-cache` package.