### PR TITLE
SN-1683 Fix definitions to match interface

### DIFF
--- a/AbstractCachePool.php
+++ b/AbstractCachePool.php
@@ -414,7 +414,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function get($key, $default = null)
+    public function get(string $key, $default = null): mixed
     {
         $item = $this->getItem($key);
         if (!$item->isHit()) {

--- a/AbstractCachePool.php
+++ b/AbstractCachePool.php
@@ -167,7 +167,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): bool
     {
         // Clear the deferred items
         $this->deferred = [];

--- a/AbstractCachePool.php
+++ b/AbstractCachePool.php
@@ -427,7 +427,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $item = $this->getItem($key);
         $item->set($value);
@@ -439,7 +439,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function delete($key)
+    public function delete(string $key): bool
     {
         return $this->deleteItem($key);
     }
@@ -447,7 +447,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         if (!is_array($keys)) {
             if (!$keys instanceof \Traversable) {
@@ -485,7 +485,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         if (!is_array($values)) {
             if (!$values instanceof \Traversable) {
@@ -524,7 +524,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         if (!is_array($keys)) {
             if (!$keys instanceof \Traversable) {
@@ -542,7 +542,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return $this->hasItem($key);
     }


### PR DESCRIPTION
This pull request updates the method signatures in `AbstractCachePool.php` to include more precise type hints and return types. These changes improve code clarity, enforce stricter type safety, and enhance IDE support.

**Type hint and return type improvements:**

* Added return type declarations (`bool`, `mixed`, `iterable`) to methods such as `clear`, `get`, `set`, `delete`, `getMultiple`, `setMultiple`, `deleteMultiple`, and `has` to clarify their expected outputs. [[1]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL170-R170) [[2]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL417-R417) [[3]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL430-R430) [[4]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL442-R450) [[5]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL488-R488) [[6]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL527-R527) [[7]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL545-R545)
* Updated parameter type hints for methods to require stricter types (e.g., `string $key`, `iterable $keys`, `mixed $value`) and more accurately reflect accepted values for TTL parameters (`null|int|\DateInterval $ttl`). [[1]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL417-R417) [[2]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL430-R430) [[3]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL488-R488) [[4]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL527-R527) [[5]](diffhunk://#diff-7b29116b32b380a03cd2de5eeeadaec7aac791c9692dae1b29f54de62f484e6dL545-R545)

These changes help catch type-related bugs earlier and make the codebase easier to understand and maintain.
